### PR TITLE
Fixed type hinting for "after" filter registration

### DIFF
--- a/src/VTalbot/Pjax/PjaxServiceProvider.php
+++ b/src/VTalbot/Pjax/PjaxServiceProvider.php
@@ -3,9 +3,9 @@
 namespace VTalbot\Pjax;
 
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Symfony\Component\DomCrawler\Crawler;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 class PjaxServiceProvider extends ServiceProvider {
 


### PR DESCRIPTION
In fact, "request" and "response" arguments passed to "after" filter is instances of Symfony's classes, not Laravel. For example, in case of redirect response previous code will fail
